### PR TITLE
Modal: replace click event for mousedown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1hive/1hive-ui",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "1Hive llc <hello@1hive.org>",
   "license": "MIT",
   "repository": "github:1hive/1hive-ui",

--- a/src/components/EscapeOutside/EscapeOutside.js
+++ b/src/components/EscapeOutside/EscapeOutside.js
@@ -21,14 +21,18 @@ class EscapeOutside extends React.Component {
     const { useCapture } = this.props
     this._document = this._element.ownerDocument
     this._document.addEventListener('keydown', this.handleEscape, useCapture)
-    this._document.addEventListener('click', this.handleClick, useCapture)
+    this._document.addEventListener('mousedown', this.handleClick, useCapture)
     this._document.addEventListener('touchend', this.handleClick, useCapture)
   }
 
   componentWillUnmount() {
     const { useCapture } = this.props
     this._document.removeEventListener('keydown', this.handleEscape, useCapture)
-    this._document.removeEventListener('click', this.handleClick, useCapture)
+    this._document.removeEventListener(
+      'mousedown',
+      this.handleClick,
+      useCapture
+    )
     this._document.removeEventListener('touchend', this.handleClick, useCapture)
   }
 


### PR DESCRIPTION
We need to do this in order to when start clicking inside the modal and releasing outside getting the modal closed