### PR TITLE
Support border on disabled Button

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -90,7 +90,7 @@ function modeStyles(theme, mode, disabled) {
       background: theme.disabled,
       color: theme.disabledContent,
       iconColor: theme.disabledContent,
-      border: '0',
+      border: `1px solid ${theme.disabledBorder}`,
     }
   }
   if (mode === 'strong') {

--- a/src/theme/theme-dark.js
+++ b/src/theme/theme-dark.js
@@ -70,6 +70,7 @@ export default {
   selectedDisabled: '#212B36',
 
   disabled: '#3f4e6f',
+  disabledBorder: '#3f4e6f',
   disabledContent: '#8497bf',
   disabledIcon: '#6683c3',
 

--- a/src/theme/theme-light.js
+++ b/src/theme/theme-light.js
@@ -70,6 +70,7 @@ export default {
   selectedDisabled: '#C4CDD5',
 
   disabled: '#E9E9E9',
+  disabledBorder: '#E9E9E9',
   disabledContent: '#818181',
   disabledIcon: '#818181',
 


### PR DESCRIPTION
Supports border for disabled buttons.

Added a `disabledBorder` color to the theme.
theme-light and theme-dark use `disabled` color as the `disabledBorder` by default so that it keeps the same style where no theme customisation is made.