### PR TITLE
Fix: Some TS need better typing

### DIFF
--- a/scripts/generate-icons
+++ b/scripts/generate-icons
@@ -26,7 +26,7 @@ const SVGR_OPTIONS = {
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function ${componentName}({ size, ...${props} }) {
+function ${componentName}({ size=undefined, ...${props} }) {
   const sizeValue = useIconSize(size)
   return ${jsx}
 }

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -6,7 +6,12 @@ import { useTheme } from '../../theme/Theme'
 import { useLayout } from '../Layout/Layout'
 import { warnOnce } from '../../utils'
 
-function Box({ heading, children, padding, ...props }) {
+function Box({
+  heading = undefined,
+  children = undefined,
+  padding = undefined,
+  ...props
+}) {
   const theme = useTheme()
   const [insideSplitPrimary] = useInside('Split:primary')
   const { layoutName } = useLayout()

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -30,7 +30,15 @@ function getLayoutSize(parentWidth, breakpoints) {
 }
 
 const LayoutContext = React.createContext({})
-
+/**
+ * Some layout method
+ *
+ * @typedef {object} layoutType
+ * @property {("small" | "medium" | "large" | "max")} layoutName
+ * @property {string} layoutWidth
+ *
+ * @returns {layoutType}
+ */
 function useLayout() {
   const { layoutWidth, layoutName } = useContext(LayoutContext)
   return {

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -4,7 +4,12 @@ import ButtonBase from '../ButtonBase/ButtonBase'
 import { useTheme } from '../../theme'
 import { RADIUS } from '../../style'
 
-function Link({ onClick, href, external, ...props }) {
+function Link({
+  onClick = () => {},
+  href = undefined,
+  external = undefined,
+  ...props
+}) {
   const theme = useTheme()
 
   // `external` defaults to `true` if `href` is present, `false` otherwise.

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -13,13 +13,13 @@ import RootPortal from '../RootPortal/RootPortal'
 const SPACE_AROUND = 4 * GU
 
 function Modal({
-  children,
-  onClose,
-  onClosed,
-  padding,
-  visible,
-  width,
-  closeButton,
+  children = undefined,
+  onClose = () => {},
+  onClosed = () => {},
+  padding = undefined,
+  visible = undefined,
+  width = undefined,
+  closeButton = undefined,
   ...props
 }) {
   const theme = useTheme()

--- a/src/icons/components/IconAddUser.js
+++ b/src/icons/components/IconAddUser.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconAddUser({ size, ...props }) {
+function IconAddUser({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconAlert.js
+++ b/src/icons/components/IconAlert.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconAlert({ size, ...props }) {
+function IconAlert({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconAlignCenter.js
+++ b/src/icons/components/IconAlignCenter.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconAlignCenter({ size, ...props }) {
+function IconAlignCenter({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconAlignJustify.js
+++ b/src/icons/components/IconAlignJustify.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconAlignJustify({ size, ...props }) {
+function IconAlignJustify({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconAlignLeft.js
+++ b/src/icons/components/IconAlignLeft.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconAlignLeft({ size, ...props }) {
+function IconAlignLeft({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconAlignRight.js
+++ b/src/icons/components/IconAlignRight.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconAlignRight({ size, ...props }) {
+function IconAlignRight({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconAragon.js
+++ b/src/icons/components/IconAragon.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconAragon({ size, ...props }) {
+function IconAragon({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconArrowDown.js
+++ b/src/icons/components/IconArrowDown.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconArrowDown({ size, ...props }) {
+function IconArrowDown({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconArrowLeft.js
+++ b/src/icons/components/IconArrowLeft.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconArrowLeft({ size, ...props }) {
+function IconArrowLeft({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconArrowRight.js
+++ b/src/icons/components/IconArrowRight.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconArrowRight({ size, ...props }) {
+function IconArrowRight({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconArrowUp.js
+++ b/src/icons/components/IconArrowUp.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconArrowUp({ size, ...props }) {
+function IconArrowUp({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconAtSign.js
+++ b/src/icons/components/IconAtSign.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconAtSign({ size, ...props }) {
+function IconAtSign({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconBlock.js
+++ b/src/icons/components/IconBlock.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconBlock({ size, ...props }) {
+function IconBlock({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconBookmark.js
+++ b/src/icons/components/IconBookmark.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconBookmark({ size, ...props }) {
+function IconBookmark({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCalendar.js
+++ b/src/icons/components/IconCalendar.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCalendar({ size, ...props }) {
+function IconCalendar({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCanvas.js
+++ b/src/icons/components/IconCanvas.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCanvas({ size, ...props }) {
+function IconCanvas({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCaution.js
+++ b/src/icons/components/IconCaution.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCaution({ size, ...props }) {
+function IconCaution({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCenter.js
+++ b/src/icons/components/IconCenter.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCenter({ size, ...props }) {
+function IconCenter({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconChart.js
+++ b/src/icons/components/IconChart.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconChart({ size, ...props }) {
+function IconChart({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconChat.js
+++ b/src/icons/components/IconChat.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconChat({ size, ...props }) {
+function IconChat({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCheck.js
+++ b/src/icons/components/IconCheck.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCheck({ size, ...props }) {
+function IconCheck({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconChip.js
+++ b/src/icons/components/IconChip.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconChip({ size, ...props }) {
+function IconChip({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCircleCheck.js
+++ b/src/icons/components/IconCircleCheck.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCircleCheck({ size, ...props }) {
+function IconCircleCheck({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCircleMinus.js
+++ b/src/icons/components/IconCircleMinus.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCircleMinus({ size, ...props }) {
+function IconCircleMinus({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCirclePlus.js
+++ b/src/icons/components/IconCirclePlus.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCirclePlus({ size, ...props }) {
+function IconCirclePlus({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconClock.js
+++ b/src/icons/components/IconClock.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconClock({ size, ...props }) {
+function IconClock({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCloudDownload.js
+++ b/src/icons/components/IconCloudDownload.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCloudDownload({ size, ...props }) {
+function IconCloudDownload({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCloudUpload.js
+++ b/src/icons/components/IconCloudUpload.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCloudUpload({ size, ...props }) {
+function IconCloudUpload({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCoin.js
+++ b/src/icons/components/IconCoin.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCoin({ size, ...props }) {
+function IconCoin({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconConfiguration.js
+++ b/src/icons/components/IconConfiguration.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconConfiguration({ size, ...props }) {
+function IconConfiguration({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconConnect.js
+++ b/src/icons/components/IconConnect.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconConnect({ size, ...props }) {
+function IconConnect({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconConnection.js
+++ b/src/icons/components/IconConnection.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconConnection({ size, ...props }) {
+function IconConnection({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconConsole.js
+++ b/src/icons/components/IconConsole.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconConsole({ size, ...props }) {
+function IconConsole({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCopy.js
+++ b/src/icons/components/IconCopy.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCopy({ size, ...props }) {
+function IconCopy({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconCross.js
+++ b/src/icons/components/IconCross.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconCross({ size, ...props }) {
+function IconCross({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconDashedSquare.js
+++ b/src/icons/components/IconDashedSquare.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconDashedSquare({ size, ...props }) {
+function IconDashedSquare({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconDown.js
+++ b/src/icons/components/IconDown.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconDown({ size, ...props }) {
+function IconDown({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconDownload.js
+++ b/src/icons/components/IconDownload.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconDownload({ size, ...props }) {
+function IconDownload({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconEdit.js
+++ b/src/icons/components/IconEdit.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconEdit({ size, ...props }) {
+function IconEdit({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconEllipsis.js
+++ b/src/icons/components/IconEllipsis.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconEllipsis({ size, ...props }) {
+function IconEllipsis({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconEnter.js
+++ b/src/icons/components/IconEnter.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconEnter({ size, ...props }) {
+function IconEnter({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconEthereum.js
+++ b/src/icons/components/IconEthereum.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconEthereum({ size, ...props }) {
+function IconEthereum({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconExternal.js
+++ b/src/icons/components/IconExternal.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconExternal({ size, ...props }) {
+function IconExternal({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconFile.js
+++ b/src/icons/components/IconFile.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconFile({ size, ...props }) {
+function IconFile({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconFilter.js
+++ b/src/icons/components/IconFilter.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconFilter({ size, ...props }) {
+function IconFilter({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconFlag.js
+++ b/src/icons/components/IconFlag.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconFlag({ size, ...props }) {
+function IconFlag({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconFolder.js
+++ b/src/icons/components/IconFolder.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconFolder({ size, ...props }) {
+function IconFolder({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconGraph.js
+++ b/src/icons/components/IconGraph.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconGraph({ size, ...props }) {
+function IconGraph({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconGraph2.js
+++ b/src/icons/components/IconGraph2.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconGraph2({ size, ...props }) {
+function IconGraph2({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconGrid.js
+++ b/src/icons/components/IconGrid.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconGrid({ size, ...props }) {
+function IconGrid({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconGroup.js
+++ b/src/icons/components/IconGroup.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconGroup({ size, ...props }) {
+function IconGroup({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconHash.js
+++ b/src/icons/components/IconHash.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconHash({ size, ...props }) {
+function IconHash({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconHeart.js
+++ b/src/icons/components/IconHeart.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconHeart({ size, ...props }) {
+function IconHeart({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconHide.js
+++ b/src/icons/components/IconHide.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconHide({ size, ...props }) {
+function IconHide({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconHome.js
+++ b/src/icons/components/IconHome.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconHome({ size, ...props }) {
+function IconHome({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconImage.js
+++ b/src/icons/components/IconImage.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconImage({ size, ...props }) {
+function IconImage({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconInfo.js
+++ b/src/icons/components/IconInfo.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconInfo({ size, ...props }) {
+function IconInfo({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconLabel.js
+++ b/src/icons/components/IconLabel.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconLabel({ size, ...props }) {
+function IconLabel({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconLayers.js
+++ b/src/icons/components/IconLayers.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconLayers({ size, ...props }) {
+function IconLayers({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconLeft.js
+++ b/src/icons/components/IconLeft.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconLeft({ size, ...props }) {
+function IconLeft({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconLink.js
+++ b/src/icons/components/IconLink.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconLink({ size, ...props }) {
+function IconLink({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconLocation.js
+++ b/src/icons/components/IconLocation.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconLocation({ size, ...props }) {
+function IconLocation({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconLock.js
+++ b/src/icons/components/IconLock.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconLock({ size, ...props }) {
+function IconLock({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconMail.js
+++ b/src/icons/components/IconMail.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconMail({ size, ...props }) {
+function IconMail({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconMaximize.js
+++ b/src/icons/components/IconMaximize.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconMaximize({ size, ...props }) {
+function IconMaximize({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconMenu.js
+++ b/src/icons/components/IconMenu.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconMenu({ size, ...props }) {
+function IconMenu({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconMinimize.js
+++ b/src/icons/components/IconMinimize.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconMinimize({ size, ...props }) {
+function IconMinimize({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconMinus.js
+++ b/src/icons/components/IconMinus.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconMinus({ size, ...props }) {
+function IconMinus({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconMove.js
+++ b/src/icons/components/IconMove.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconMove({ size, ...props }) {
+function IconMove({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconNoPicture.js
+++ b/src/icons/components/IconNoPicture.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconNoPicture({ size, ...props }) {
+function IconNoPicture({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconPicture.js
+++ b/src/icons/components/IconPicture.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconPicture({ size, ...props }) {
+function IconPicture({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconPlus.js
+++ b/src/icons/components/IconPlus.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconPlus({ size, ...props }) {
+function IconPlus({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconPower.js
+++ b/src/icons/components/IconPower.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconPower({ size, ...props }) {
+function IconPower({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconPrint.js
+++ b/src/icons/components/IconPrint.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconPrint({ size, ...props }) {
+function IconPrint({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconProhibited.js
+++ b/src/icons/components/IconProhibited.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconProhibited({ size, ...props }) {
+function IconProhibited({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconQuestion.js
+++ b/src/icons/components/IconQuestion.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconQuestion({ size, ...props }) {
+function IconQuestion({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconRefresh.js
+++ b/src/icons/components/IconRefresh.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconRefresh({ size, ...props }) {
+function IconRefresh({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconRemoveUser.js
+++ b/src/icons/components/IconRemoveUser.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconRemoveUser({ size, ...props }) {
+function IconRemoveUser({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconRight.js
+++ b/src/icons/components/IconRight.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconRight({ size, ...props }) {
+function IconRight({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconRotateLeft.js
+++ b/src/icons/components/IconRotateLeft.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconRotateLeft({ size, ...props }) {
+function IconRotateLeft({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconRotateRight.js
+++ b/src/icons/components/IconRotateRight.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconRotateRight({ size, ...props }) {
+function IconRotateRight({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconSearch.js
+++ b/src/icons/components/IconSearch.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconSearch({ size, ...props }) {
+function IconSearch({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconSettings.js
+++ b/src/icons/components/IconSettings.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconSettings({ size, ...props }) {
+function IconSettings({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconShare.js
+++ b/src/icons/components/IconShare.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconShare({ size, ...props }) {
+function IconShare({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconSquare.js
+++ b/src/icons/components/IconSquare.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconSquare({ size, ...props }) {
+function IconSquare({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconSquareMinus.js
+++ b/src/icons/components/IconSquareMinus.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconSquareMinus({ size, ...props }) {
+function IconSquareMinus({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconSquarePlus.js
+++ b/src/icons/components/IconSquarePlus.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconSquarePlus({ size, ...props }) {
+function IconSquarePlus({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconStar.js
+++ b/src/icons/components/IconStar.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconStar({ size, ...props }) {
+function IconStar({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconStarFilled.js
+++ b/src/icons/components/IconStarFilled.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconStarFilled({ size, ...props }) {
+function IconStarFilled({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconSwap.js
+++ b/src/icons/components/IconSwap.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconSwap({ size, ...props }) {
+function IconSwap({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconTarget.js
+++ b/src/icons/components/IconTarget.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconTarget({ size, ...props }) {
+function IconTarget({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconToken.js
+++ b/src/icons/components/IconToken.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconToken({ size, ...props }) {
+function IconToken({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconTrash.js
+++ b/src/icons/components/IconTrash.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconTrash({ size, ...props }) {
+function IconTrash({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconUnlock.js
+++ b/src/icons/components/IconUnlock.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconUnlock({ size, ...props }) {
+function IconUnlock({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconUp.js
+++ b/src/icons/components/IconUp.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconUp({ size, ...props }) {
+function IconUp({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconUpload.js
+++ b/src/icons/components/IconUpload.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconUpload({ size, ...props }) {
+function IconUpload({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconUser.js
+++ b/src/icons/components/IconUser.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconUser({ size, ...props }) {
+function IconUser({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconView.js
+++ b/src/icons/components/IconView.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconView({ size, ...props }) {
+function IconView({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconVote.js
+++ b/src/icons/components/IconVote.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconVote({ size, ...props }) {
+function IconVote({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconWallet.js
+++ b/src/icons/components/IconWallet.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconWallet({ size, ...props }) {
+function IconWallet({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconWarning.js
+++ b/src/icons/components/IconWarning.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconWarning({ size, ...props }) {
+function IconWarning({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconWorld.js
+++ b/src/icons/components/IconWorld.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconWorld({ size, ...props }) {
+function IconWorld({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconWrite.js
+++ b/src/icons/components/IconWrite.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconWrite({ size, ...props }) {
+function IconWrite({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconZoomIn.js
+++ b/src/icons/components/IconZoomIn.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconZoomIn({ size, ...props }) {
+function IconZoomIn({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/icons/components/IconZoomOut.js
+++ b/src/icons/components/IconZoomOut.js
@@ -2,7 +2,7 @@ import React from 'react'
 import useIconSize from '../icon-size'
 import IconPropTypes from '../IconPropTypes'
 
-function IconZoomOut({ size, ...props }) {
+function IconZoomOut({ size = undefined, ...props }) {
   const sizeValue = useIconSize(size)
   return (
     <svg

--- a/src/providers/Root/Root.js
+++ b/src/providers/Root/Root.js
@@ -3,7 +3,17 @@ import PropTypes from 'prop-types'
 
 const RootContext = React.createContext(null)
 
-function RootProvider({ children, ...props }) {
+/**
+ * RootProvider
+ *
+ * @typedef {object} RootProvider
+ * @property {any} [children]
+ * @property {[*]} [props]
+ *
+ * @param {RootProvider}
+ * @returns {React.FC}
+ */
+function RootProvider({ children = undefined, ...props }) {
   const [element, setElement] = useState(null)
 
   const handleRef = useCallback(element => {
@@ -41,6 +51,9 @@ RootProvider.propTypes = {
 function Root(props) {
   return <RootContext.Consumer {...props} />
 }
+/**
+ * @type {React.FC}
+ */
 Root.Provider = RootProvider
 
 const useRoot = () => useContext(RootContext)


### PR DESCRIPTION
Aftter the generated d.ts typing version, some components need refactor or make all params optional

It's unlock the https://github.com/1Hive/gardens-ui/pull/749 of @tmoutinho 

Meanwhile its possible use the Gist with already fixed `index.d.ts`

https://gist.github.com/kamikazebr/88528d30f2a55eb4ffb49773ea50f13c

place on `node_modules/@1hive/1hive-ui/dist/types/index.d.ts`
