### PR TITLE
fix: update `Info` mode types

### DIFF
--- a/src/components/Info/Info.js
+++ b/src/components/Info/Info.js
@@ -97,11 +97,18 @@ Info.propTypes = {
 }
 
 // Backward compatibility
+function Description(props) {
+  return <Info mode="description" {...props} />
+}
 function Warning(props) {
   return <Info mode="warning" {...props} />
 }
-Info.Action = Info
-Info.Permissions = Warning
-Info.Alert = Warning
+function Error(props) {
+  return <Info mode="error" {...props} />
+}
+
+Info.Description = Description
+Info.Warning = Warning
+Info.Error = Error
 
 export default Info

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1464,7 +1464,7 @@ export declare function Info({
   [x: string]: any
   children?: any
   title?: any
-  mode?: Info.MODES
+  mode?: Info.Modes
   color?: string
   titleColor?: string
   background?: string
@@ -1472,25 +1472,17 @@ export declare function Info({
 }): JSX.Element
 
 export declare namespace Info {
-  export enum MODES  {
-    INFO='info', 
-    WARNING='warning', 
-    ERROR='error', 
-    DESCRIPTION='description'
-  }
+  export type Modes  =
+    | 'info'
+    | 'description'
+    | 'warning'
+    | 'error'
 
-  export {
-    Info as Action
-  }
-  export {
-    Warning as Permissions
-  }
-  export {
-    Warning as Alert
-  }
+  export function Description(props: any): JSX.Element
+  export function Error(props: any): JSX.Element
+  export function Warning(props: any): JSX.Element
 }
 
-export declare function Warning(props: any): JSX.Element
 
 
 export declare function initContainsComponent(): {


### PR DESCRIPTION
This PR fixes the `Info` component enum types and the wrapped components to use a specific info mode.